### PR TITLE
Refactor CLI imports and depcheck enforcement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "yaml": "2.7.1"
       },
       "bin": {
-        "cedit": "dist/ui/cli/index.js"
+        "cedit": "dist/index.js"
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
     "lint": "eslint --fix .",
-    "depcheck": "depcruise src --config dependency-cruiser.cjs --output-type err",
+    "depcheck": "node scripts/depcheck.mjs",
     "typecheck": "tsc --noEmit",
     "pkg-lint": "npmPkgJsonLint ."
   },

--- a/scripts/depcheck.mjs
+++ b/scripts/depcheck.mjs
@@ -1,0 +1,47 @@
+import { execa } from 'execa';
+import path from 'node:path';
+
+const DEP_CRUISE_CMD = 'npx';
+const DEP_CRUISE_ARGS = ['depcruise', 'src', '--config', 'dependency-cruiser.cjs', '--output-type', 'json'];
+
+function isDownwardIndexImport(fromPath, toPath) {
+  if (!new RegExp(`${path.sep}index\\.(ts|js)$`).test(toPath)) {
+    return false;
+  }
+  const fromDirs = path.dirname(fromPath).split(path.sep);
+  const toDirs = path.dirname(toPath).split(path.sep);
+  return (
+    fromDirs.length > toDirs.length &&
+    fromDirs.slice(0, toDirs.length).every((p, i) => p === toDirs[i])
+  );
+}
+
+async function main() {
+  const { stdout } = await execa(DEP_CRUISE_CMD, DEP_CRUISE_ARGS);
+  const result = JSON.parse(stdout);
+  if (result.summary.error > 0) {
+    console.error('Dependency Cruiser reported violations');
+    process.exit(1);
+  }
+  const violations = [];
+
+  for (const mod of result.modules) {
+    for (const dep of mod.dependencies) {
+      if (isDownwardIndexImport(mod.source, dep.resolved)) {
+        violations.push(`${mod.source} -> ${dep.resolved}`);
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error('Downward index imports detected:\n' + violations.join('\n'));
+    process.exit(1);
+  } else {
+    console.log('✔ no downward index imports found');
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/ui/cli/config/definitions.ts
+++ b/src/ui/cli/config/definitions.ts
@@ -2,7 +2,7 @@
  * Definitions for CLI configuration metadata.
  */
 import type { CliConfig, LogConfig, BackupConfig, DefaultConfig } from '../../../app/model/index.js'; // Adjusted path
-import type { CliFlags } from '../main.js'; // Adjusted path
+import type { CliFlags } from '../types.js';
 import {
   parseYamlString,
   parseAndResolvePath,

--- a/src/ui/cli/config/loader.ts
+++ b/src/ui/cli/config/loader.ts
@@ -8,7 +8,7 @@ import yaml from 'yaml';
 import chalk from 'chalk';
 import * as fs from 'node:fs/promises';
 import type { CliConfig } from '../../../app/model/index.js'; // Adjusted path
-import type { CliFlags } from '../main.js'; // Adjusted path
+import type { CliFlags } from '../types.js';
 import { type ZodIssue, type ZodError } from 'zod'; // Added ZodError for type safety
 import {
   PartialCliConfigFromFileSchema,

--- a/src/ui/cli/execution/flow.ts
+++ b/src/ui/cli/execution/flow.ts
@@ -9,7 +9,7 @@ import { startProcessing } from './lifecycle.js'; // Adjusted path
 import { performInitialSetup } from './setup.js'; // Adjusted path
 import type { Logger } from 'pino';
 import { ResourceManager } from '../services/resource-manager.js'; // Adjusted path
-import type { CliFlags } from '../main.js'; // Adjusted path
+import type { CliFlags } from '../types.js';
 import { ProgressMonitor } from '../services/progress-monitor.js'; // Adjusted path
 import { CompletionHandler } from '../handlers/completion-handler.js'; // Adjusted path
 

--- a/src/ui/cli/execution/lifecycle.ts
+++ b/src/ui/cli/execution/lifecycle.ts
@@ -5,7 +5,7 @@ import { bus, BusEventType } from '../../../app/bus/index.js'; // Adjusted path
 import type { CliConfig } from '../../../app/model/index.js'; // Adjusted path
 import { parseArguments } from './parser.js'; // Adjusted path and function name
 import { loadConfiguration } from '../config/loader.js'; // Adjusted path
-import type { CliFlags } from '../main.js'; // Adjusted path
+import type { CliFlags } from '../types.js';
 import type { Logger } from 'pino';
 
 /**

--- a/src/ui/cli/execution/parser.ts
+++ b/src/ui/cli/execution/parser.ts
@@ -2,7 +2,7 @@
  * CLI argument parsing utilities
  */
 import { Command } from 'commander';
-import type { CliFlags, CommanderOptionValues } from '../main.js'; // Adjusted path
+import type { CliFlags, CommanderOptionValues } from '../types.js';
 import chalk from 'chalk';
 import { getVersion } from '../services/version-manager.js'; // Adjusted path and function name
 

--- a/src/ui/cli/execution/setup.ts
+++ b/src/ui/cli/execution/setup.ts
@@ -6,7 +6,7 @@ import type { CliConfig } from '../../../app/model/index.js'; // Adjusted path
 import { parseArguments } from './parser.js'; // Adjusted path and function name
 import { loadConfiguration } from '../config/loader.js'; // Adjusted path
 import { getVersion } from '../services/version-manager.js'; // Adjusted path and function name
-import type { CliFlags } from '../main.js'; // Adjusted path
+import type { CliFlags } from '../types.js';
 import type { Logger } from 'pino';
 
 /**

--- a/src/ui/cli/handlers/confirmation-handler.ts
+++ b/src/ui/cli/handlers/confirmation-handler.ts
@@ -4,7 +4,7 @@
 import chalk from 'chalk';
 import type { Logger } from 'pino';
 import { bus, BusEventType } from '../../../app/bus/index.js'; // Adjusted path
-import type { CliFlags } from '../main.js'; // Adjusted path, assuming CliFlags will be in main.ts
+import type { CliFlags } from '../types.js';
 
 /**
  * Waits for the TUI to send an INIT_COMPLETE event indicating user confirmation or cancellation.

--- a/src/ui/cli/index.ts
+++ b/src/ui/cli/index.ts
@@ -3,43 +3,10 @@
  */
 import chalk from 'chalk';
 import type { CliConfig } from '../../app/model/index.js';
-import { orchestrateExecution } from './execution/flow.js'; // Adjusted path
+import { orchestrateExecution } from './execution/flow.js';
 import type { Logger } from 'pino';
-import type { ResourceManager } from './services/resource-manager.js'; // Adjusted path and type name
+import type { ResourceManager } from './services/resource-manager.js';
 
-/**
- * Interface representing raw CLI flags parsed from command line.
- * This is used by multiple modules, so it remains here as a central definition.
- */
-export interface CliFlags { 
-  spec: string;
-  dry_run: boolean | undefined;
-  var: string[];
-  log_level: string | undefined; 
-  log_dir?: string;
-  backup_dir?: string;
-  max_tokens?: number;
-  model?: string;
-  retries?: number;
-  sleep_ms?: number;
-  yes: boolean;
-}
-
-/**
- * Interface for options returned by Commander.js program.opts().
- */
-export interface CommanderOptionValues {
-  dryRun?: boolean;
-  var?: string[];
-  logLevel?: string;
-  logDir?: string;
-  backupDir?: string;
-  maxTokens?: number;
-  model?: string;
-  retries?: number;
-  sleepMs?: number;
-  yes?: boolean;
-}
 
 /**
  * Handles critical errors that occur during CLI execution.
@@ -97,3 +64,5 @@ export async function runCli(
     }
   }
 }
+
+export type { CliFlags, CommanderOptionValues } from './types.js';

--- a/src/ui/cli/types.ts
+++ b/src/ui/cli/types.ts
@@ -1,0 +1,26 @@
+export interface CliFlags {
+  spec: string;
+  dry_run: boolean | undefined;
+  var: string[];
+  log_level: string | undefined;
+  log_dir?: string;
+  backup_dir?: string;
+  max_tokens?: number;
+  model?: string;
+  retries?: number;
+  sleep_ms?: number;
+  yes: boolean;
+}
+
+export interface CommanderOptionValues {
+  dryRun?: boolean;
+  var?: string[];
+  logLevel?: string;
+  logDir?: string;
+  backupDir?: string;
+  maxTokens?: number;
+  model?: string;
+  retries?: number;
+  sleepMs?: number;
+  yes?: boolean;
+}

--- a/tests/cli-config.test.ts
+++ b/tests/cli-config.test.ts
@@ -13,7 +13,7 @@ import mock from 'mock-fs';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { runCli } from '../src/ui/cli/main.js'; // Updated import path
+import { runCli } from '../src/ui/cli/index.js';
 import { loadConfigFile } from '../src/ui/cli/config/loader.js'; // Updated import path
 
 // Mock @clack/prompts functions to prevent console output during tests

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -35,7 +35,7 @@
  */
 
 // import { describe, it, expect, vi, beforeEach, type Mock } from \'vitest\';
-// import { runCli, type RunFn } from \'../src/ui/cli/main.js\';
+// import { runCli, type RunFn } from \'../src/ui/cli/index.js\';
 // import { parseCliArgs as originalParseCliArgs, type ParsedCliArgs } from \'../src/ui/cli/execution/parser.js\';
 // import { loadConfig as originalLoadConfig, type ResolvedConfig, type ConfigError } from \'../src/ui/cli/config/loader.js\';
 // import { initializeResourceManager as originalInitializeResourceManager, type ResourceManager } from \'../src/ui/cli/services/resource-manager.js\';
@@ -385,7 +385,7 @@
 // });
 
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
-import { runCli } from '../src/ui/cli/main.js';
+import { runCli } from '../src/ui/cli/index.js';
 import { orchestrateExecution } from '../src/ui/cli/execution/flow.js';
 import type { CliConfig } from '../src/app/model/index.js';
 import type { Logger } from 'pino';


### PR DESCRIPTION
## Summary
- split CLI flag interfaces into a new `types.ts`
- update submodules and tests to import from `index.js`
- restore depcheck script checking for downward index imports

## Testing
- `npm run lint`
- `npm run typecheck`
- `npx vitest run`
- `npm run depcheck`
